### PR TITLE
Rework the notification system

### DIFF
--- a/formbuilder/actions/notifications.js
+++ b/formbuilder/actions/notifications.js
@@ -3,7 +3,12 @@ import uuid from "uuid";
 export const NOTIFICATION_ADD = "NOTIFICATION_ADD";
 export const NOTIFICATION_REMOVE = "NOTIFICATION_REMOVE";
 
-export function addNotification(message, type="info", autoDismiss=true) {
+export function addNotification(message, type="info", autoDismiss=null) {
+  if (type=="error" && autoDismiss == null) {
+    autoDismiss = false;
+  } else {
+    autoDismiss = true;
+  }
   return (dispatch) => {
     const id = uuid.v4();
     dispatch({type: NOTIFICATION_ADD, notification: {id, message, type}});

--- a/formbuilder/actions/notifications.js
+++ b/formbuilder/actions/notifications.js
@@ -3,14 +3,23 @@ import uuid from "uuid";
 export const NOTIFICATION_ADD = "NOTIFICATION_ADD";
 export const NOTIFICATION_REMOVE = "NOTIFICATION_REMOVE";
 
-export function addNotification(message, type="info", autoDismiss=null, dismissAfter=5000) {
+
+export function addNotification(message, options) {
+  const defaultOptions = {
+    type: "info",
+    autoDismiss: null,
+    dismissAfter: 5000
+  };
+  let {type, autoDismiss, dismissAfter} = {
+    ...defaultOptions,
+    ...options
+  };
   if (autoDismiss == null) {
-    autoDismiss = (type=="error") ? false : true;
+    autoDismiss = (type == "error") ? false : true;
   }
   return (dispatch) => {
     const id = uuid.v4();
     dispatch({type: NOTIFICATION_ADD, notification: {id, message, type}});
-    console.log("AutoDismiss", autoDismiss);
     if (autoDismiss == true) {
       setTimeout(() => {
         dispatch({type: NOTIFICATION_REMOVE, id});

--- a/formbuilder/actions/notifications.js
+++ b/formbuilder/actions/notifications.js
@@ -1,10 +1,20 @@
+import uuid from "uuid";
+
 export const NOTIFICATION_ADD = "NOTIFICATION_ADD";
 export const NOTIFICATION_REMOVE = "NOTIFICATION_REMOVE";
 
-export function addNotification(notification) {
-  return {type: NOTIFICATION_ADD, notification};
+export function addNotification(message, type="info", autoDismiss=true) {
+  return (dispatch) => {
+    const id = uuid.v4();
+    dispatch({type: NOTIFICATION_ADD, notification: {id, message, type}});
+    if (autoDismiss == true) {
+      setTimeout(() => {
+        dispatch({type: NOTIFICATION_REMOVE, id});
+      }, 5000);
+    }
+  };
 }
 
-export function removeNotification(index) {
-  return {type: NOTIFICATION_REMOVE, index};
+export function removeNotification(id) {
+  return {type: NOTIFICATION_REMOVE, id};
 }

--- a/formbuilder/actions/notifications.js
+++ b/formbuilder/actions/notifications.js
@@ -15,12 +15,12 @@ export function addNotification(message, options) {
     ...options
   };
   if (autoDismiss == null) {
-    autoDismiss = (type == "error") ? false : true;
+    autoDismiss = type !== "error";
   }
   return (dispatch) => {
     const id = uuid.v4();
     dispatch({type: NOTIFICATION_ADD, notification: {id, message, type}});
-    if (autoDismiss == true) {
+    if (autoDismiss === true) {
       setTimeout(() => {
         dispatch({type: NOTIFICATION_REMOVE, id});
       }, dismissAfter);

--- a/formbuilder/actions/notifications.js
+++ b/formbuilder/actions/notifications.js
@@ -3,19 +3,18 @@ import uuid from "uuid";
 export const NOTIFICATION_ADD = "NOTIFICATION_ADD";
 export const NOTIFICATION_REMOVE = "NOTIFICATION_REMOVE";
 
-export function addNotification(message, type="info", autoDismiss=null) {
-  if (type=="error" && autoDismiss == null) {
-    autoDismiss = false;
-  } else {
-    autoDismiss = true;
+export function addNotification(message, type="info", autoDismiss=null, dismissAfter=5000) {
+  if (autoDismiss == null) {
+    autoDismiss = (type=="error") ? false : true;
   }
   return (dispatch) => {
     const id = uuid.v4();
     dispatch({type: NOTIFICATION_ADD, notification: {id, message, type}});
+    console.log("AutoDismiss", autoDismiss);
     if (autoDismiss == true) {
       setTimeout(() => {
         dispatch({type: NOTIFICATION_REMOVE, id});
-      }, 5000);
+      }, dismissAfter);
     }
   };
 }

--- a/formbuilder/actions/server.js
+++ b/formbuilder/actions/server.js
@@ -37,7 +37,7 @@ export function publishForm(callback) {
       }
     })
     .catch((error) => {
-      dispatch(addNotification({type: "error", message: error.message}));
+      dispatch(addNotification(error.message, "error"));
     });
   };
 }

--- a/formbuilder/actions/server.js
+++ b/formbuilder/actions/server.js
@@ -37,7 +37,7 @@ export function publishForm(callback) {
       }
     })
     .catch((error) => {
-      dispatch(addNotification(error.message, "error"));
+      dispatch(addNotification(error.message, {type: "error"}));
     });
   };
 }
@@ -55,7 +55,7 @@ export function submitRecord(record, collectionID, callback) {
       }
     })
     .catch((error) => {
-      dispatch(addNotification(error.message, "error"));
+      dispatch(addNotification(error.message, {type: "error"}));
     });
   };
 }
@@ -74,7 +74,7 @@ export function loadSchema(collectionID, callback) {
       }
     })
     .catch((error) => {
-      dispatch(addNotification(error.message, "error"));
+      dispatch(addNotification(error.message, {type: "error"}));
     });
   };
 }
@@ -93,7 +93,7 @@ export function getRecords(collectionID, callback) {
       }
     })
     .catch((error) => {
-      dispatch(addNotification(error.message, "error"));
+      dispatch(addNotification(error.message, {type: "error"}));
     });
   };
 }

--- a/formbuilder/actions/server.js
+++ b/formbuilder/actions/server.js
@@ -55,7 +55,7 @@ export function submitRecord(record, collectionID, callback) {
       }
     })
     .catch((error) => {
-      dispatch(addNotification({type: "error", message: error.message}));
+      dispatch(addNotification(error.message, "error"));
     });
   };
 }
@@ -74,7 +74,7 @@ export function loadSchema(collectionID, callback) {
       }
     })
     .catch((error) => {
-      dispatch(addNotification({type: "error", message: error.message}));
+      dispatch(addNotification(error.message, "error"));
     });
   };
 }
@@ -93,7 +93,7 @@ export function getRecords(collectionID, callback) {
       }
     })
     .catch((error) => {
-      dispatch(addNotification({type: "error", message: error.message}));
+      dispatch(addNotification(error.message, "error"));
     });
   };
 }

--- a/formbuilder/components/NotificationList.js
+++ b/formbuilder/components/NotificationList.js
@@ -17,8 +17,8 @@ export default function NotificationList(props) {
         const classes = `alert alert-${ERROR_CLASSES[type]}`;
         return (
           <div key={id} className={classes}>
-            <a href="#" className="close"
-              onClick={() => removeNotification(id)}>×</a>
+            <a className="close"
+               onClick={() => removeNotification(id)}>×</a>
             {message}
           </div>
         );

--- a/formbuilder/components/NotificationList.js
+++ b/formbuilder/components/NotificationList.js
@@ -18,7 +18,7 @@ export default function NotificationList(props) {
         return (
           <div key={id} className={classes}>
             <a className="close"
-               onClick={() => removeNotification(id)}>×</a>
+              onClick={() => removeNotification(id)}>×</a>
             {message}
           </div>
         );

--- a/formbuilder/components/NotificationList.js
+++ b/formbuilder/components/NotificationList.js
@@ -12,13 +12,13 @@ export default function NotificationList(props) {
   }
   return (
     <div>{
-      notifications.map((notif, index) => {
-        const {message, type} = notif;
+      notifications.map((notif) => {
+        const {message, type, id} = notif;
         const classes = `alert alert-${ERROR_CLASSES[type]}`;
         return (
-          <div key={index} className={classes}>
+          <div key={id} className={classes}>
             <a href="#" className="close"
-              onClick={() => removeNotification(index)}>×</a>
+              onClick={() => removeNotification(id)}>×</a>
             {message}
           </div>
         );

--- a/formbuilder/reducers/notifications.js
+++ b/formbuilder/reducers/notifications.js
@@ -12,7 +12,7 @@ export default function collections(state = INITIAL_STATE, action) {
     return [...state, action.notification];
 
   case NOTIFICATION_REMOVE:
-    return state.filter((obj) => action.id !== obj.id);
+    return state.filter(({id}) => action.id !== id);
 
   default:
     return state;

--- a/formbuilder/reducers/notifications.js
+++ b/formbuilder/reducers/notifications.js
@@ -12,7 +12,7 @@ export default function collections(state = INITIAL_STATE, action) {
     return [...state, action.notification];
 
   case NOTIFICATION_REMOVE:
-    return state.filter((notif, index) => action.index !== index);
+    return state.filter((obj) => action.id !== obj.id);
 
   default:
     return state;

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "react-router": "^1.0.3",
     "redux": "^3.0.5",
     "redux-thunk": "^1.0.3",
-    "slug": "^0.9.1"
+    "slug": "^0.9.1",
+    "uuid": "^2.0.2"
   },
   "devDependencies": {
     "babel": "^5.8.20",

--- a/test/actions/notifications_test.js
+++ b/test/actions/notifications_test.js
@@ -1,0 +1,96 @@
+/*eslint no-unused-vars: [2, { "varsIgnorePattern": "^d$" }]*/
+
+import { expect } from "chai";
+import sinon from "sinon";
+
+import {
+  NOTIFICATION_ADD,
+  addNotification
+} from "../../formbuilder/actions/notifications";
+
+describe("notifications actions", () => {
+  let sandbox;
+  let dispatch;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+    dispatch = sandbox.stub();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe("addNotification", () => {
+    it("should send info notifications by default", (done) => {
+      addNotification("Some info message")(({type, notification}) => {
+        expect(type).to.eql(NOTIFICATION_ADD);
+        expect(notification.message ).to.eql("Some info message");
+        expect(notification.type).to.eql("info");
+        done();
+      });
+    });
+
+    it("should send error notifications if specified", (done) => {
+      addNotification("Some error message", "error")(({type, notification}) => {
+        expect(type).to.eql(NOTIFICATION_ADD);
+        expect(notification.message ).to.eql("Some error message");
+        expect(notification.type).to.eql("error");
+        done();
+      });
+    });
+    describe("With fake timers", () => {
+      beforeEach(() => {
+        sandbox.useFakeTimers();
+      });
+
+      it("should dismiss a message after a specific time", () => {
+        addNotification("Some dismissable message", "info", true, 2)(dispatch);
+        sinon.assert.calledWithMatch(dispatch, {
+          type: "NOTIFICATION_ADD",
+          notification: {
+            id: sinon.match.string,
+            message: "Some dismissable message",
+            type: "info"
+          }
+        });
+        sandbox.clock.tick(3);
+        sinon.assert.calledWithMatch(dispatch, {
+          type: "NOTIFICATION_REMOVE",
+          id: sinon.match.string
+        });
+      });
+
+      it("should not dismiss an undismissable message", () => {
+        addNotification("Some dismissable message", "info", false, 2)(dispatch);
+        sinon.assert.calledWithMatch(dispatch, {
+          type: "NOTIFICATION_ADD",
+          notification: {
+            id: sinon.match.string,
+            message: "Some dismissable message",
+            type: "info"
+          }
+        });
+        sandbox.clock.tick(3);
+        expect(dispatch.calledOnce).to.be.true;
+      });
+
+      it("should dismiss messages by default", () => {
+        addNotification("Some dismissable message")(dispatch);
+        sinon.assert.calledWithMatch(dispatch, {
+          type: "NOTIFICATION_ADD",
+          notification: {
+            id: sinon.match.string,
+            message: "Some dismissable message",
+            type: "info"
+          }
+        });
+        sandbox.clock.tick(6000);
+        sinon.assert.calledWithMatch(dispatch, {
+          type: "NOTIFICATION_REMOVE",
+          id: sinon.match.string
+        });
+      });
+    });
+  });
+});

--- a/test/actions/notifications_test.js
+++ b/test/actions/notifications_test.js
@@ -32,7 +32,7 @@ describe("notifications actions", () => {
     });
 
     it("should send error notifications if specified", (done) => {
-      addNotification("Some error message", "error")(({type, notification}) => {
+      addNotification("Some error message", {type: "error"})(({type, notification}) => {
         expect(type).to.eql(NOTIFICATION_ADD);
         expect(notification.message ).to.eql("Some error message");
         expect(notification.type).to.eql("error");
@@ -45,7 +45,11 @@ describe("notifications actions", () => {
       });
 
       it("should dismiss a message after a specific time", () => {
-        addNotification("Some dismissable message", "info", true, 2)(dispatch);
+        addNotification("Some dismissable message", {
+          type: "info",
+          autoDismiss: true,
+          dismissAfter: 2
+        })(dispatch);
         sinon.assert.calledWithMatch(dispatch, {
           type: "NOTIFICATION_ADD",
           notification: {
@@ -62,7 +66,11 @@ describe("notifications actions", () => {
       });
 
       it("should not dismiss an undismissable message", () => {
-        addNotification("Some dismissable message", "info", false, 2)(dispatch);
+        addNotification("Some dismissable message", {
+          type: "info",
+          autoDismiss: false,
+          dismissAfter: 2
+        })(dispatch);
         sinon.assert.calledWithMatch(dispatch, {
           type: "NOTIFICATION_ADD",
           notification: {

--- a/test/actions/notifications_test.js
+++ b/test/actions/notifications_test.js
@@ -25,16 +25,17 @@ describe("notifications actions", () => {
     it("should send info notifications by default", (done) => {
       addNotification("Some info message")(({type, notification}) => {
         expect(type).to.eql(NOTIFICATION_ADD);
-        expect(notification.message ).to.eql("Some info message");
+        expect(notification.message).to.eql("Some info message");
         expect(notification.type).to.eql("info");
         done();
       });
     });
 
     it("should send error notifications if specified", (done) => {
-      addNotification("Some error message", {type: "error"})(({type, notification}) => {
+      const thunk = addNotification("Some error message", {type: "error"});
+      thunk(({type, notification}) => {
         expect(type).to.eql(NOTIFICATION_ADD);
-        expect(notification.message ).to.eql("Some error message");
+        expect(notification.message).to.eql("Some error message");
         expect(notification.type).to.eql("error");
         done();
       });

--- a/test/actions/server_test.js
+++ b/test/actions/server_test.js
@@ -23,6 +23,23 @@ import {
   NOTIFICATION_ADD
 } from "../../formbuilder/actions/notifications";
 
+function getErrorDispatch(done) {
+  return (func) => {
+    if (typeof func === "function") {
+      func((payload) => {
+        if (payload.type == NOTIFICATION_ADD) {
+          try {
+            expect(payload.notification.message).to.eql("error message");
+            expect(payload.notification.type).to.eql("error");
+            done();
+          } catch(e) {
+            return done(e);
+          }
+        }
+      });
+    }
+  };
+}
 
 describe("server actions", () => {
   let sandbox;
@@ -97,17 +114,7 @@ describe("server actions", () => {
         });
       });
       it("should dispatch an error if an http error occurs", (done) => {
-        dispatch = (payload) => {
-          if (payload.type == NOTIFICATION_ADD) {
-            try {
-              expect(payload.notification.type).to.eql("error");
-              expect(payload.notification.message).to.eql("error message");
-              done();
-            } catch(e) {
-              return done(e);
-            }
-          }
-        };
+        dispatch = getErrorDispatch(done);
         publishForm(() => {
           done(new Error("Redirect shouldn't be called!"));
         })(dispatch, getState);
@@ -154,17 +161,7 @@ describe("server actions", () => {
         });
       });
       it("should dispatch an error if an http error occurs", (done) => {
-        dispatch = (payload) => {
-          if (payload.type == NOTIFICATION_ADD) {
-            try {
-              expect(payload.notification.type).to.eql("error");
-              expect(payload.notification.message).to.eql("error message");
-              done();
-            } catch(e) {
-              return done(e);
-            }
-          }
-        };
+        dispatch = getErrorDispatch(done);
         submitRecord(() => {
           done(new Error("Redirect shouldn't be called!"));
         })(dispatch, getState);
@@ -219,17 +216,7 @@ describe("server actions", () => {
         });
       });
       it("should dispatch an error if an http error occurs", (done) => {
-        dispatch = (payload) => {
-          if (payload.type == NOTIFICATION_ADD) {
-            try {
-              expect(payload.notification.type).to.eql("error");
-              expect(payload.notification.message).to.eql("error message");
-              done();
-            } catch(e) {
-              return done(e);
-            }
-          }
-        };
+        dispatch = getErrorDispatch(done);
         loadSchema(collectionID, () => {
           done(new Error("Redirect shouldn't be called!"));
         })(dispatch, getState);
@@ -283,17 +270,7 @@ describe("server actions", () => {
         });
       });
       it("should dispatch an error if an http error occurs", (done) => {
-        dispatch = (payload) => {
-          if (payload.type == NOTIFICATION_ADD) {
-            try {
-              expect(payload.notification.type).to.eql("error");
-              expect(payload.notification.message).to.eql("error message");
-              done();
-            } catch(e) {
-              return done(e);
-            }
-          }
-        };
+        dispatch = getErrorDispatch(done);
         getRecords(() => {
           done(new Error("Redirect shouldn't be called!"));
         })(dispatch, getState);

--- a/test/actions/server_test.js
+++ b/test/actions/server_test.js
@@ -25,19 +25,21 @@ import {
 
 function getErrorDispatch(done) {
   return (func) => {
-    if (typeof func === "function") {
-      func((payload) => {
-        if (payload.type == NOTIFICATION_ADD) {
-          try {
-            expect(payload.notification.message).to.eql("error message");
-            expect(payload.notification.type).to.eql("error");
-            done();
-          } catch(e) {
-            return done(e);
-          }
-        }
-      });
+    if (typeof func !== "function") {
+      return;
     }
+
+    func((payload) => {
+      if (payload.type == NOTIFICATION_ADD) {
+        try {
+          expect(payload.notification.message).to.eql("error message");
+          expect(payload.notification.type).to.eql("error");
+          done();
+        } catch(e) {
+          return done(e);
+        }
+      }
+    });
   };
 }
 


### PR DESCRIPTION
The current notification system has some issues:

- Notifications stay until you dismiss them, it should be an option,
- When you dismiss them, you're being redirected, whereas that's not the behaviour we would like,
- We should be able to attach some actions inside the notifications (for instance, undo), but we currently don't have any way to do this.