### PR TITLE
Try adding widgets via drag-and-drop *and* simple click

### DIFF
--- a/formbuilder/components/builder/FieldList.js
+++ b/formbuilder/components/builder/FieldList.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { Link } from "react-router";
+import { Draggable } from "react-drag-and-drop";
 
 
 function MenuSection(props) {
@@ -10,13 +11,13 @@ function MenuSection(props) {
       <div className="list-group">{
         fields.map((field, index) => {
           return (
-            <div key={index} type="field"
+            <Draggable key={index} type="field"
               onClick={_ => props.onClick(field)}
               data={JSON.stringify(field)}
               className="list-group-item field-list-entry">
               <i className={`glyphicon glyphicon-${field.icon}`} />&nbsp;
               <span>{field.label}</span>
-            </div>
+            </Draggable>
           );
         })
       }</div>

--- a/formbuilder/styles.css
+++ b/formbuilder/styles.css
@@ -90,6 +90,11 @@ textarea.json-viewer {
   cursor: move;
 }
 
+.field-list-entry:active {
+  background: #F7F7F7;
+  box-shadow: inset 0 -2px 2px -2px rgba(0, 0, 0, .3);
+}
+
 .glyphicon + span {
   margin-left: .5em;
 }


### PR DESCRIPTION
The ability to insert new widgets via drag-and-drop was removed with #45. We should have a look at how to have the two behaviours at the same time, if possible.