### PR TITLE
Add infos in readme to fix unmet peer dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,17 @@ page](https://kinto.github.io/formbuilder/)
 # Installation
 
 To run the formbuilder locally, you can issue the following commands:
-
-   $ git clone https://github.com/Kinto/formbuilder.git
-   $ cd formbuilder
-   $ npm install
-   $ npm run start
+```
+$ git clone https://github.com/Kinto/formbuilder.git  
+$ cd formbuilder  
+$ npm install  
+```
+Then install the unmet peer dependencies  
+```
+$ npm install react@^0.14.8  
+$ npm install react-dom@^0.14.3  
+```
+And run!  
+```
+$ npm run start  
+```

--- a/README.md
+++ b/README.md
@@ -12,14 +12,6 @@ To run the formbuilder locally, you can issue the following commands:
 ```
 $ git clone https://github.com/Kinto/formbuilder.git  
 $ cd formbuilder  
-$ npm install  
-```
-Then install the unmet peer dependencies  
-```
-$ npm install react@^0.14.8  
-$ npm install react-dom@^0.14.3  
-```
-And run!  
-```
+$ npm install
 $ npm run start  
 ```

--- a/package.json
+++ b/package.json
@@ -17,11 +17,9 @@
     "dist",
     "lib"
   ],
-  "peerDependencies": {
-    "react": "^0.14.3",
-    "react-dom": "^0.14.3"
-  },
   "dependencies": {
+    "react": "^0.14.8",
+    "react-dom": "^0.14.8",
     "btoa": "^1.1.2",
     "history": "^1.17.0",
     "isomorphic-fetch": "^2.2.1",


### PR DESCRIPTION
Not sure about react and react-dom versions you use but I had unmet peer depencencies after running npm install... Fixed like this. It is normal to do the installation manually?