### PR TITLE
(DO NOT MERGE) Persist edition statuts

### DIFF
--- a/formbuilder/actions/fieldlist.js
+++ b/formbuilder/actions/fieldlist.js
@@ -5,7 +5,12 @@ export const FIELD_INSERT = "FIELD_INSERT";
 export const FIELD_SWAP = "FIELD_SWAP";
 export const FORM_RESET = "FORM_RESET";
 export const FORM_UPDATE_PROPERTIES = "FORM_UPDATE_PROPERTIES";
+export const SET_EDIT_STATE = "SET_EDIT_STATE";
 
+
+export function setEditState(name, edit) {
+  return {type: SET_EDIT_STATE, name, edit};
+}
 
 export function addField(field) {
   return {type: FIELD_ADD, field};

--- a/formbuilder/components/builder/EditableField.js
+++ b/formbuilder/components/builder/EditableField.js
@@ -93,24 +93,26 @@ function DraggableFieldContainer(props) {
 export default class EditableField extends Component {
   constructor(props) {
     super(props);
-    this.state = {edit: false, schema: props.schema};
+    this.state = {edit: props.editionState[props.name], schema: props.schema};
   }
 
   componentWillReceiveProps(nextProps) {
-    this.setState({edit: false, schema: nextProps.schema});
+    this.setEditState(this.props.name, false);
+    this.setState({schema: nextProps.schema});
   }
 
   handleEdit(event) {
     event.preventDefault();
     if (shouldHandleDoubleClick(event.target)) {
-      this.setState({edit: true});
+      this.setEditState(this.props.name, true);
     }
   }
 
   handleUpdate({formData}) {
     const updated = pickKeys(this.props.schema, formData);
     const schema = {...this.props.schema, ...updated};
-    this.setState({edit: false, schema});
+    this.setEditState(this.props.name, true);
+    this.setState({schema});
     this.props.updateField(
       this.props.name, schema, formData.required, formData.title);
   }
@@ -124,7 +126,7 @@ export default class EditableField extends Component {
 
   handleCancel(event) {
     event.preventDefault();
-    this.setState({edit: false});
+    this.setEditState(this.props.name, false);
   }
 
   handleDrop(data) {
@@ -141,7 +143,7 @@ export default class EditableField extends Component {
   render() {
     const props = this.props;
 
-    if (this.state.edit) {
+    if (this.props.edit) {
       return (
         <FieldPropertiesEditor
           {...props}

--- a/formbuilder/containers/builder/FormContainer.js
+++ b/formbuilder/containers/builder/FormContainer.js
@@ -9,11 +9,13 @@ import EditableField from "../../components/builder/EditableField";
 
 
 function mapStateToProps(state) {
+  console.log(state);
   return {
     error: state.form.error,
     schema: state.form.schema,
     uiSchema: state.form.uiSchema,
     formData: state.form.formData,
+    editionState: state.form.editionState,
     status: state.serverStatus.status,
   };
 }

--- a/formbuilder/reducers/form.js
+++ b/formbuilder/reducers/form.js
@@ -7,6 +7,7 @@ import {
   FIELD_SWAP,
   FORM_RESET,
   FORM_UPDATE_PROPERTIES,
+  SET_EDIT_STATE
 } from "../actions/fieldlist";
 
 import {SCHEMA_RETRIEVAL_DONE} from "../actions/server";
@@ -22,6 +23,7 @@ const INITIAL_STATE = {
     "ui:order": []
   },
   formData: {},
+  editionState: {},
   currentIndex: 0,
 };
 
@@ -45,6 +47,13 @@ function addField(state, field) {
   state.schema.properties[_slug] = {...field.jsonSchema, title: name};
   state.uiSchema[_slug] = field.uiSchema;
   state.uiSchema["ui:order"] = (state.uiSchema["ui:order"] || []).concat(_slug);
+
+  // Activate the "edit" mode after addition, but only for the last
+  // added widget.
+  for (var id in state.editionState) {
+    state.editionState[id] = false;
+  }
+  state.editionState[_slug] = true;
   return state;
 }
 
@@ -138,6 +147,11 @@ function setSchema(state, data) {
   return {...state, error: null};
 }
 
+function setEditState(state, name, edit) {
+  state.editionState[name] = edit;
+  return {...state, error: null};
+}
+
 export default function form(state = INITIAL_STATE, action) {
   switch(action.type) {
   case FIELD_ADD:
@@ -157,6 +171,8 @@ export default function form(state = INITIAL_STATE, action) {
     return updateFormProperties(clone(state), action.properties);
   case SCHEMA_RETRIEVAL_DONE:
     return setSchema(clone(state), action.data);
+  case SET_EDIT_STATE:
+    return setEditState(clone(state), action.name, action.state);
   default:
     return state;
   }


### PR DESCRIPTION
This is a start of a solution for #37.

However, this won't work because I don't have any way to get access to the store from an `EditableField` (a `SchemaField` in terms of rjsf terminology). This is probably because the props [are all passed explicitely](http://github.com/mozilla-services/react-jsonschema-form/blob/3f698af51de4764c792fd359c79fa5f89532c4a3/src/components/fields/ObjectField.js#L100-L111).

I would love to have any help on this, I'm blocked :)