### PR TITLE
(WIP) Handle permissions

### DIFF
--- a/devServer.js
+++ b/devServer.js
@@ -2,7 +2,7 @@ var path = require("path");
 var express = require("express");
 var webpack = require("webpack");
 
-var env = "dev", port = 8080;
+var env = "dev", port = 9000;
 
 var webpackConfig = require("./webpack.config." + env);
 var compiler = webpack(webpackConfig);

--- a/formbuilder/actions/server.js
+++ b/formbuilder/actions/server.js
@@ -169,11 +169,10 @@ export function loadSchema(collection, callback) {
     })
     .bucket(config.server.bucket)
     .collection(collection)
-    .getAttributes().then(({data}) => {
-      console.log("Metadata", data);
+    .getData().then((data) => {
       dispatch({
         type: SCHEMA_RETRIEVAL_DONE,
-        data: data
+        data,
       });
       if (callback) {
         callback(data);

--- a/formbuilder/actions/server.js
+++ b/formbuilder/actions/server.js
@@ -6,6 +6,7 @@ import {addNotification} from "./notifications";
 import {getUserToken} from "../utils";
 import config from "../config";
 
+
 export const FORM_PUBLISH = "FORM_PUBLISH";
 
 export const FORM_PUBLICATION_PENDING = "FORM_PUBLICATION_PENDING";
@@ -134,6 +135,7 @@ export function publishForm(callback) {
 
 /**
  * Submit a new form answer.
+ * New credentials are created for each answer.
  **/
 export function submitRecord(record, collection, callback) {
   return (dispatch, getState) => {
@@ -185,6 +187,8 @@ export function loadSchema(collection, callback) {
 
 /**
  * Retrieve all the answers to a specific form.
+ *
+ * The userToken is derived from the the adminToken.
  **/
 export function getRecords(adminToken, callback) {
   return (dispatch, getState) => {

--- a/formbuilder/components/AdminView.js
+++ b/formbuilder/components/AdminView.js
@@ -3,9 +3,10 @@ import CSVDownloader from "./CSVDownloader";
 
 export default class AdminView extends Component {
   componentDidMount() {
-    const collectionID = this.props.params.id;
-    this.props.getRecords(collectionID);
-    this.props.loadSchema(collectionID);
+    const collection = this.props.params.id;
+    const adminToken = this.props.params.adminToken;
+    this.props.getRecords(collection, adminToken);
+    this.props.loadSchema(collection);
   }
   render() {
     const properties = this.props.schema.properties;
@@ -26,15 +27,15 @@ export default class AdminView extends Component {
         <thead>
           <tr>{
             schemaFields.map((key) => {
-              return <th>{properties[key].title}</th>;
+              return <th key={key}>{properties[key].title}</th>;
             })
           }</tr>
         </thead>
         <tbody>
         {this.props.records.map((record) => {
-          return (<tr>{
+          return (<tr key={record.id}>{
             schemaFields.map((key) => {
-              return <td>{String(record[key])}</td>;
+              return <td key={key}>{String(record[key])}</td>;
             }
           )}
           </tr>);

--- a/formbuilder/components/AdminView.js
+++ b/formbuilder/components/AdminView.js
@@ -1,11 +1,12 @@
 import React, { Component } from "react";
 import CSVDownloader from "./CSVDownloader";
+import {getUserToken} from "../utils.js";
 
 export default class AdminView extends Component {
   componentDidMount() {
-    const collection = this.props.params.id;
     const adminToken = this.props.params.adminToken;
-    this.props.getRecords(collection, adminToken);
+    const collection = getUserToken(adminToken);
+    this.props.getRecords(adminToken);
     this.props.loadSchema(collection);
   }
   render() {

--- a/formbuilder/components/FormCreated.js
+++ b/formbuilder/components/FormCreated.js
@@ -2,10 +2,11 @@ import React from "react";
 
 
 export default function FormCreated(props) {
-  const collectionID = props.params.id;
+  const collection = props.params.id;
+  const adminToken = props.params.adminToken;
   const origin = window.location.origin + window.location.pathname;
-  const userformURL = `${origin}#/form/${collectionID}`;
-  const adminURL = `${origin}#/admin/${collectionID}`;
+  const userformURL = `${origin}#/form/${collection}`;
+  const adminURL = `${origin}#/admin/${collection}/${adminToken}`;
 
   const onClick = (e) => {
     e.target.select();

--- a/formbuilder/components/FormCreated.js
+++ b/formbuilder/components/FormCreated.js
@@ -1,12 +1,12 @@
 import React from "react";
-
+import {getUserToken} from "../utils";
 
 export default function FormCreated(props) {
-  const collection = props.params.id;
   const adminToken = props.params.adminToken;
+  const userToken = getUserToken(adminToken);
   const origin = window.location.origin + window.location.pathname;
-  const userformURL = `${origin}#/form/${collection}`;
-  const adminURL = `${origin}#/admin/${collection}/${adminToken}`;
+  const userformURL = `${origin}#/form/${userToken}`;
+  const adminURL = `${origin}#/admin/${adminToken}`;
 
   const onClick = (e) => {
     e.target.select();

--- a/formbuilder/components/builder/Form.js
+++ b/formbuilder/components/builder/Form.js
@@ -10,7 +10,7 @@ export default function EditableForm(props) {
 
   const onClick = (event) => {
     props.publishForm(({collection, adminToken}) => {
-      props.history.pushState(null, `/builder/published/${collection}/${adminToken}`);
+      props.history.pushState(null, `/builder/published/${adminToken}`);
     });
   };
 

--- a/formbuilder/components/builder/Form.js
+++ b/formbuilder/components/builder/Form.js
@@ -9,8 +9,8 @@ export default function EditableForm(props) {
   const {properties} = schema;
 
   const onClick = (event) => {
-    props.publishForm((collectionID) => {
-      props.history.pushState(null, `/builder/published/${collectionID}`);
+    props.publishForm(({collection, adminToken}) => {
+      props.history.pushState(null, `/builder/published/${collection}/${adminToken}`);
     });
   };
 

--- a/formbuilder/config.js
+++ b/formbuilder/config.js
@@ -1,7 +1,7 @@
 export default {
   server: {
     remote: process.env.SERVER_URL,
-    auth: "token:formbuilder"
+    bucket: "formbuilder",
   },
   fieldList: [
     {

--- a/formbuilder/reducers/serverStatus.js
+++ b/formbuilder/reducers/serverStatus.js
@@ -6,7 +6,7 @@ import {
 
 const INITIAL_STATE = {
   status: "init",
-  collectionID: null,
+  collection: null,
 };
 
 export default function serverStatus(state = INITIAL_STATE, action) {
@@ -22,7 +22,7 @@ export default function serverStatus(state = INITIAL_STATE, action) {
     return {
       ...state,
       status: "done",
-      collectionID: action.collectionID,
+      collection: action.collection,
     };
   default:
     return state;

--- a/formbuilder/routes.js
+++ b/formbuilder/routes.js
@@ -42,13 +42,13 @@ export default (
         components={{...common, sidebarComponent: LinkToBuilder, content: FormOptionsContainer}} />
       <Route path="builder/json"
         components={{...common, sidebarComponent: LinkToBuilder, content: JsonViewContainer}} />
-      <Route path="builder/published/:id"
+      <Route path="builder/published/:id/:adminToken"
         components={{...common, sidebarComponent: Check, content: FormCreatedContainer}} />
       <Route path="form/data-sent"
         components={{...common, sidebarComponent: Check, content: RecordCreatedContainer}} />
       <Route path="form/:id"
         components={{...common, sidebarComponent: null, header: null, content: UserFormContainer}} />
-      <Route path="admin/:id"
+      <Route path="admin/:id/:adminToken"
         components={{...common, sidebarComponent: null, header: null, content: AdminViewContainer}} />
       <Route path="*" components={{
         sidebarComponent: FieldListContainer,

--- a/formbuilder/routes.js
+++ b/formbuilder/routes.js
@@ -42,13 +42,13 @@ export default (
         components={{...common, sidebarComponent: LinkToBuilder, content: FormOptionsContainer}} />
       <Route path="builder/json"
         components={{...common, sidebarComponent: LinkToBuilder, content: JsonViewContainer}} />
-      <Route path="builder/published/:id/:adminToken"
+      <Route path="builder/published/:adminToken"
         components={{...common, sidebarComponent: Check, content: FormCreatedContainer}} />
       <Route path="form/data-sent"
         components={{...common, sidebarComponent: Check, content: RecordCreatedContainer}} />
       <Route path="form/:id"
         components={{...common, sidebarComponent: null, header: null, content: UserFormContainer}} />
-      <Route path="admin/:id/:adminToken"
+      <Route path="admin/:adminToken"
         components={{...common, sidebarComponent: null, header: null, content: AdminViewContainer}} />
       <Route path="*" components={{
         sidebarComponent: FieldListContainer,

--- a/formbuilder/utils.js
+++ b/formbuilder/utils.js
@@ -1,0 +1,10 @@
+/**
+ * Returns the user token from the administration token.
+ *
+ * The user token is also used as the name of the collection where the records
+ * are stored. This is useful to always have one id to pass to the clients,
+ * and they can figure out what the user token and collection name is.
+ **/
+export function getUserToken(adminToken) {
+  return adminToken.slice(0, adminToken.length / 2);
+}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "btoa": "^1.1.2",
     "history": "^1.17.0",
     "isomorphic-fetch": "^2.2.1",
-    "kinto-client": "^0.6.0",
+    "kinto-client": "^0.8.0",
     "react": "^0.14.8",
     "react-dom": "^0.14.8",
     "react-drag-and-drop": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "btoa": "^1.1.2",
     "history": "^1.17.0",
     "isomorphic-fetch": "^2.2.1",
-    "kinto-client": "^0.2.3",
+    "kinto-client": "^0.6.0",
     "react": "^0.14.8",
     "react-dom": "^0.14.8",
     "react-drag-and-drop": "^2.0.1",

--- a/test/actions/server_test.js
+++ b/test/actions/server_test.js
@@ -4,7 +4,6 @@ import { expect } from "chai";
 import sinon from "sinon";
 
 import {
-  api,
   publishForm,
   submitRecord,
   loadSchema,
@@ -41,18 +40,18 @@ function getErrorDispatch(done) {
   };
 }
 
-describe("server actions", () => {
+describe.only("server actions", () => {
   let sandbox;
   let dispatch;
   let getState;
   let record;
-  let collectionID;
+  let collection;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
     dispatch = sandbox.stub();
-    collectionID: "mycoll";
-    record = {id: 1234, collectionID: collectionID};
+    collection: "mycoll";
+    record = {id: 1234, collection: collection};
 
     getState = () => {
       return {
@@ -72,7 +71,7 @@ describe("server actions", () => {
     describe("with working remote server", () => {
       let data;
       beforeEach(() => {
-        data = {id: "collectionID"};
+        data = {id: "collection"};
         sandbox.stub(api, "createCollection", () => {
           return Promise.resolve({data});
         });
@@ -97,7 +96,7 @@ describe("server actions", () => {
             });
             sinon.assert.calledWithExactly(dispatch, {
               type: FORM_PUBLICATION_DONE,
-              collectionID: data.id
+              collection: data.id
             });
             done();
           } catch(err) {
@@ -134,11 +133,11 @@ describe("server actions", () => {
       });
 
       it("should call the redirect function after a successful request", (done) => {
-        submitRecord(record, collectionID, done)(dispatch, getState);
+        submitRecord(record, collection, done)(dispatch, getState);
       });
 
       it("should call the dispatch function twice", (done) => {
-        submitRecord(record, collectionID, () => {
+        submitRecord(record, collection, () => {
           try {
             sinon.assert.calledWithExactly(dispatch, {
               type: FORM_RECORD_CREATION_PENDING
@@ -174,14 +173,14 @@ describe("server actions", () => {
     describe("with working remote server", () => {
       let data;
       beforeEach(() => {
-        data = {id: "collectionID"};
+        data = {id: "collection"};
         sandbox.stub(api, "getCollection", () => {
           return Promise.resolve({data});
         });
       });
 
       it("should call the redirect function after a successful request", (done) => {
-        loadSchema(collectionID, (schema) => {
+        loadSchema(collection, (schema) => {
           try {
             expect(schema.id).to.eql(data.id);
             done();
@@ -192,7 +191,7 @@ describe("server actions", () => {
       });
 
       it("should call the dispatch function twice", (done) => {
-        loadSchema(collectionID, () => {
+        loadSchema(collection, () => {
           try {
             sinon.assert.calledWithExactly(dispatch, {
               type: SCHEMA_RETRIEVAL_PENDING
@@ -217,7 +216,7 @@ describe("server actions", () => {
       });
       it("should dispatch an error if an http error occurs", (done) => {
         dispatch = getErrorDispatch(done);
-        loadSchema(collectionID, () => {
+        loadSchema(collection, () => {
           done(new Error("Redirect shouldn't be called!"));
         })(dispatch, getState);
       });
@@ -235,7 +234,7 @@ describe("server actions", () => {
       });
 
       it("should call the redirect function after a successful request", (done) => {
-        getRecords(collectionID, (retrieved) => {
+        getRecords(collection, (retrieved) => {
           try {
             expect(retrieved).to.eql(records);
             done();
@@ -246,7 +245,7 @@ describe("server actions", () => {
       });
 
       it("should call the dispatch function twice", (done) => {
-        getRecords(collectionID, () => {
+        getRecords(collection, () => {
           try {
             sinon.assert.calledWithExactly(dispatch, {
               type: RECORDS_RETRIEVAL_PENDING

--- a/test/actions/server_test.js
+++ b/test/actions/server_test.js
@@ -1,5 +1,6 @@
 /*eslint no-unused-vars: [2, { "varsIgnorePattern": "^d$" }]*/
 
+import KintoClient from "kinto-client";
 import { expect } from "chai";
 import sinon from "sinon";
 
@@ -69,6 +70,23 @@ describe.only("server actions", () => {
 
   describe("publishForm", () => {
     describe("with working remote server", () => {
+
+      it("should get the userid when using serverInfo", () => {
+        sandbox.stub(KintoClient, "constructor").
+      });
+      it("should create the collection with the expected permissions", () => {
+
+      });
+      it("should call initializeBucket if the bucket doesn't exist", () => {
+
+      });
+      it("should dispatch an error if the serverInfo request fails", () => {
+
+      });
+      it("should dispatch an error if createCollection fails", () => {
+
+      });
+
       let data;
       beforeEach(() => {
         data = {id: "collection"};


### PR DESCRIPTION
This changes how permissions are handled.

A new bucket is created if it doesn't exist already. It is created with open permissions: any authenticated user can create collections in it. Once created, administrative permissions are removed for the creator: the aim is to have no other admin than the host.

On form creation, two different tokens are used: the admin token and the user token. The user token is derived from the adminToken so that it's possible to get it back without transmitting it explicitly. This is similar to what e.g. doodle does.

Each time a new record (answer to the form) is submitted, a temporary user is created. This is useless for now but can serve in the future to let users changes their submissions.

## todo

- [x] Change the permissions system
- [x] Use short links (derive userToken from adminToken)
- [ ] Update the tests