### PR TITLE
Fix the Simulate.submit() tests.

### DIFF
--- a/test/components/EditableField_test.js
+++ b/test/components/EditableField_test.js
@@ -4,7 +4,7 @@ import { expect } from "chai";
 import sinon from "sinon";
 import { Simulate } from "react-addons-test-utils";
 
-import { createComponent } from "../test-utils";
+import { createComponent, d } from "../test-utils";
 import config from "../../formbuilder/config";
 import EditableField from "../../formbuilder/components/builder/EditableField";
 
@@ -46,14 +46,15 @@ describe("EditableField", () => {
         .eql(true);
     });
 
-    it.skip("should update field properties", () => {
+    it("should update field properties", () => {
       const value = "modified";
       Simulate.change(comp.query("[type=text][value='Edit me']"), {
         target: {value}
       });
-      Simulate.submit(comp.query("form"));
-
-      expect(comp.query("label").textContent).eql(value);
+      return new Promise(setImmediate).then(() => {
+        Simulate.submit(comp.query("form"));
+        expect(comp.query("label").textContent).eql(value);
+      });
     });
   });
 

--- a/test/components/UserForm_test.js
+++ b/test/components/UserForm_test.js
@@ -51,7 +51,7 @@ describe("UserForm", () => {
     expect(compProps.loadSchema.calledOnce).to.be.True;
   });
 
-  it.skip("should submit the new record and redirect on submission", (done) => {
+  it("should submit the new record and redirect on submission", (done) => {
     sinon.stub(compProps, "submitRecord", (formData, id, callback) => {
       expect(formData).to.eql({
         "firstName": "John",
@@ -69,7 +69,10 @@ describe("UserForm", () => {
     Simulate.change(comp.query("#root_lastName"), {
       target: {value: "Doe"}
     });
-    Simulate.submit(comp.query());
-    expect(compProps.submitRecord.calledOnce).to.be.True;
+    return new Promise(setImmediate).then(() => {
+      Simulate.submit(comp.query());
+      expect(compProps.submitRecord.calledOnce).to.be.True;
+    });
+
   });
 });


### PR DESCRIPTION
Some operations where not finished when the assumption was checked, and the
tests weren't passing as a result. Using `setImmediate` fixed it.

r? @n1k0 