### PR TITLE
404 link to kinto doc

### DIFF
--- a/formbuilder/components/Welcome.js
+++ b/formbuilder/components/Welcome.js
@@ -25,7 +25,7 @@ export default function Welcome(props) {
         <div className="col-md-4">
           <h3><i className="glyphicon glyphicon-eye-close"></i> Privacy matters</h3>
           <p>With <a href="https://kinto-storage.org">Kinto</a>, you are not giving Google or any other giants your data.</p>
-          <p>Our goal is not to host all the forms of the world, so we try to make it easy for you to <a href="http://kinto.readthedocs.org/en/latest/get-started.html#get-started">host your own servers</a>.</p>
+          <p>Our goal is not to host all the forms of the world, so we try to make it easy for you to <a href="http://kinto.readthedocs.io/en/stable/tutorials/install.html">host your own servers</a>.</p>
         </div>
         <div className="col-md-4">
           <h3><i className="glyphicon glyphicon-heart-empty"></i> Open source</h3>


### PR DESCRIPTION
Note sure this is the correct link to point to, but the current one on https://kinto.github.io/formbuilder/#/ leads to a 404 error.