### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/formbuilder/components/Header.js
+++ b/formbuilder/components/Header.js
@@ -12,7 +12,7 @@ export default function Header(props) {
       <div className="navbar-collapse collapse">
         <ul className="nav navbar-nav navbar-right">
           <li><Link to="/faq">FAQ</Link></li>
-          <li><a href="http://kinto.readthedocs.org/en/latest/overview.html">Our values</a></li>
+          <li><a href="https://kinto.readthedocs.io/en/latest/overview.html">Our values</a></li>
         </ul>
       </div>
     </div>

--- a/formbuilder/components/Welcome.js
+++ b/formbuilder/components/Welcome.js
@@ -25,7 +25,7 @@ export default function Welcome(props) {
         <div className="col-md-4">
           <h3><i className="glyphicon glyphicon-eye-close"></i> Privacy matters</h3>
           <p>With <a href="https://kinto-storage.org">Kinto</a>, you are not giving Google or any other giants your data.</p>
-          <p>Our goal is not to host all the forms of the world, so we try to make it easy for you to <a href="http://kinto.readthedocs.io/en/stable/tutorials/install.html">host your own servers</a>.</p>
+          <p>Our goal is not to host all the forms of the world, so we try to make it easy for you to <a href="https://kinto.readthedocs.io/en/stable/tutorials/install.html">host your own servers</a>.</p>
         </div>
         <div className="col-md-4">
           <h3><i className="glyphicon glyphicon-heart-empty"></i> Open source</h3>

--- a/formbuilder/index.prod.html
+++ b/formbuilder/index.prod.html
@@ -13,7 +13,7 @@
   <script src="./bundle.js"></script>
   <noscript>
     <p>We're sorry, but you need JavaScript to access this website. JavaScript
-    is used to communicate with an external <a href="https://kinto.readthedocs.org">Kinto</a>
+    is used to communicate with an external <a href="https://kinto.readthedocs.io">Kinto</a>
     server where the form data is stored.</p>
     <p>Without it, we cannot either save or retrieve the data on this external server.</p>
   </noscript>


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.