### PR TITLE
Add delete button when editing field

### DIFF
--- a/formbuilder/components/builder/EditableField.js
+++ b/formbuilder/components/builder/EditableField.js
@@ -47,7 +47,7 @@ class FieldPropertiesEditor extends Component {
             close <i className="glyphicon glyphicon-remove-sign"/>
           </button>
           <button type="button" className="close-btn" onClick={onDelete} aria-label="Delete">
-            delete <i className="glyphicon glyphicon-remove-sign"/>
+            delete <i className="glyphicon glyphicon-trash"/>
           </button>
         </div>
         <div className="panel-body">
@@ -84,7 +84,7 @@ function DraggableFieldContainer(props) {
               edit <i className="glyphicon glyphicon-edit"/>
             </button>
             <button type="button" className="delete-btn" onClick={onDelete}>
-              delete <i className="glyphicon glyphicon-remove-sign"/>
+              delete <i className="glyphicon glyphicon-trash"/>
             </button>
           </div>
         </div>

--- a/formbuilder/components/builder/EditableField.js
+++ b/formbuilder/components/builder/EditableField.js
@@ -32,7 +32,7 @@ class FieldPropertiesEditor extends Component {
   }
 
   render() {
-    const {schema, name, required, uiSchema, cancel, update} = this.props;
+    const {schema, name, required, uiSchema, onCancel, onUpdate, onDelete} = this.props;
     const formData = {
       ...schema,
       required,
@@ -43,8 +43,11 @@ class FieldPropertiesEditor extends Component {
       <div className="panel panel-default field-editor">
         <div className="panel-heading">
           <strong>Edit {name}</strong>
-          <button type="button" className="close-btn" onClick={cancel} aria-label="Close">
+          <button type="button" className="close-btn" onClick={onCancel} aria-label="Close">
             close <i className="glyphicon glyphicon-remove-sign"/>
+          </button>
+          <button type="button" className="close-btn" onClick={onDelete} aria-label="Delete">
+            delete <i className="glyphicon glyphicon-remove-sign"/>
           </button>
         </div>
         <div className="panel-body">
@@ -52,7 +55,7 @@ class FieldPropertiesEditor extends Component {
             schema={uiSchema.editSchema}
             formData={formData}
             onChange={this.onChange.bind(this)}
-            onSubmit={update} />
+            onSubmit={onUpdate} />
         </div>
       </div>
     );
@@ -145,8 +148,9 @@ export default class EditableField extends Component {
       return (
         <FieldPropertiesEditor
           {...props}
-          cancel={this.handleCancel.bind(this)}
-          update={this.handleUpdate.bind(this)} />
+          onCancel={this.handleCancel.bind(this)}
+          onUpdate={this.handleUpdate.bind(this)}
+          onDelete={this.handleDelete.bind(this)} />
       );
     }
 

--- a/formbuilder/styles.css
+++ b/formbuilder/styles.css
@@ -72,7 +72,6 @@ form > p {
 
 .panel-heading .close-btn {
   float: right;
-  margin-right: -1em;
 }
 
 textarea.json-viewer {


### PR DESCRIPTION
It is constrained to have to close the field to be able to delete it.
So I added the delete button in field editor :)

![Field editor with delete button](https://cloud.githubusercontent.com/assets/8366021/16650047/54733c48-443c-11e6-88e1-c27cb29e40f9.png)

I removed the margin to prevent the buttons overlap