### PR TITLE
issus #115 - Add the ability to save the jsonschema directly

### DIFF
--- a/formbuilder/components/builder/JsonSchemaDownloader.js
+++ b/formbuilder/components/builder/JsonSchemaDownloader.js
@@ -1,0 +1,16 @@
+import React from "react";
+import { Link } from "react-router";
+
+import btoa from "btoa";
+
+export default function JsonSchemaDownloader(props) {
+  const filename = props.schema.title + ".json";
+  const fileContent = "data:text/plain;base64," + btoa(JSON.stringify(props.schema));
+
+  return (
+    <Link className="list-group-item" download={filename} to={fileContent}>
+      <i className="glyphicon glyphicon-download" />&nbsp;
+        Download JSON
+    </Link>
+  )
+}

--- a/formbuilder/containers/builder/JsonSchemaDownloaderContainer.js
+++ b/formbuilder/containers/builder/JsonSchemaDownloaderContainer.js
@@ -1,0 +1,13 @@
+import { connect } from "react-redux";
+
+import JsonSchemaDownloader from "../../components/builder/JsonSchemaDownloader";
+
+function mapStateToProps(state) {
+  return {
+    schema: state.form.schema,
+  };
+}
+
+export default connect(
+  mapStateToProps,
+)(JsonSchemaDownloader);

--- a/formbuilder/routes.js
+++ b/formbuilder/routes.js
@@ -12,6 +12,7 @@ import UserFormContainer from "./containers/UserFormContainer";
 import RecordCreatedContainer from "./containers/RecordCreatedContainer";
 import AdminViewContainer from "./containers/AdminViewContainer";
 import WelcomeContainer from "./containers/WelcomeContainer";
+import JsonSchemaDownloaderContainer from "./containers/builder/JsonSchemaDownloaderContainer";
 import Header from "./components/Header";
 import Check from "./components/Check";
 import FAQ from "./components/FAQ";
@@ -43,6 +44,17 @@ const BackAndCheck = () => {
   );
 };
 
+const BackAndDownloadJSONSchema = () => {
+  return (
+    <div>
+      <LinkToBuilder text="Continue editing"/>
+      <div className="list-group">
+        <JsonSchemaDownloaderContainer />
+      </div>
+    </div>
+  );
+};
+
 export default (
     <Route path="/" component={App}>
       <IndexRoute components={{...common, mainComponent: WelcomeContainer}} />
@@ -51,7 +63,7 @@ export default (
       <Route path="builder"
         components={{...common, content: FormContainer}} />
       <Route path="builder/json"
-        components={{...common, sidebarComponent: LinkToBuilder, content: JsonViewContainer}} />
+        components={{...common, sidebarComponent: BackAndDownloadJSONSchema, content: JsonViewContainer}} />
       <Route path="builder/published/:adminToken"
         components={{...common, sidebarComponent: BackAndCheck, content: FormCreatedContainer}} />
       <Route path="form/data-sent"


### PR DESCRIPTION
This commit add a 'Download JSON' link in "/#/builder/json" sidebar.

printed pdf of the results: 
[Formbuilder_download_jsonschema.pdf](https://github.com/Kinto/formbuilder/files/471853/Formbuilder_download_jsonschema.pdf)
