### PR TITLE
Fix css on editable field's actions headerbar

### DIFF
--- a/formbuilder/styles.css
+++ b/formbuilder/styles.css
@@ -57,13 +57,16 @@
 .editable-field-actions {
   text-align: right;
   padding-left: 0;
-  padding-right: 0;
 }
 
 .editable-field-actions button,
 button.close-btn {
   background: none;
   border: none;
+}
+
+.editable-field-actions button:last-child {
+  padding-right: 0;
 }
 
 form > p {


### PR DESCRIPTION
Before this fix, the delete button in editable field header bar isn't align with bottom's form's actions.