### PR TITLE
Improvement: check whether defined or not before using it

### DIFF
--- a/formbuilder/actions/server.js
+++ b/formbuilder/actions/server.js
@@ -78,7 +78,7 @@ export function publishForm(callback) {
     const uiSchema = form.uiSchema;
 
     // Remove the "required" property if it's empty.
-    if (schema.required.length === 0) {
+    if (schema.required && schema.required.length === 0) {
       delete schema.required;
     }
 


### PR DESCRIPTION
To avoid getting error - `Cannot read property 'length' of undefined` when `schema.required` isn't defined.