### PR TITLE
Give some space to the header

### DIFF
--- a/formbuilder/app.js
+++ b/formbuilder/app.js
@@ -6,8 +6,8 @@ const createHashHistory = require("history/lib/createHashHistory");
 
 import routes from "./routes";
 import configureStore from "./store/configureStore";
-import "./styles.css";
 import "./bootswatch.less";
+import "./styles.css";
 
 const store = configureStore({
   notifications: [],

--- a/formbuilder/styles.css
+++ b/formbuilder/styles.css
@@ -35,6 +35,12 @@
   }
 }
 
+/* Override default navbar
+   Prevent first form element dropdown menu to get out of the viewport */
+.navbar {
+  min-height: 8em;
+}
+
 .check {
   font-size: 13em;
   color: #455;


### PR DESCRIPTION
Increased a bit default header height to prevent dropdown menu from overlapping.

![kinto-formbuilder-height](https://cloud.githubusercontent.com/assets/103008/20487523/f962533c-b003-11e6-83df-538a4be795de.png)

I checked and default Google Forms header height is around 180px, we're 104px now

fix #193 